### PR TITLE
Add LCM_C_NAMESPACE config option

### DIFF
--- a/lcm-bazel/private/expand_flag_template.bzl
+++ b/lcm-bazel/private/expand_flag_template.bzl
@@ -1,0 +1,30 @@
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+
+def _impl(ctx):
+    # Build a dictionary of the flags' current values.
+    substitutions = {}
+    for key, label in ctx.attr.flag_substitutions.items():
+        substitutions[key] = label[BuildSettingInfo].value
+
+    # Add an action to expand the template using those flags.
+    out = ctx.actions.declare_file(ctx.label.name)
+    ctx.actions.expand_template(
+        template = ctx.file.template,
+        output = out,
+        substitutions = substitutions,
+    )
+    return DefaultInfo(files = depset([out]))
+
+expand_flag_template = rule(
+    implementation = _impl,
+    attrs = {
+        "template": attr.label(
+            allow_single_file = True,
+            doc = "The template file to expand.",
+        ),
+        "flag_substitutions": attr.string_keyed_label_dict(
+            doc = "A dictionary mapping strings to the label for the flag to substitute.",
+        ),
+    },
+    doc = "Generates a file based on a template file and textual substitutions.",
+)

--- a/lcm-cmake/config.cmake
+++ b/lcm-cmake/config.cmake
@@ -70,3 +70,6 @@ if(NOT MSVC)
     -Wno-stringop-truncation
   )
 endif()
+
+# Allow the user to change the C/C++ namespace.
+set(LCM_C_NAMESPACE "lcm" CACHE STRING "The namespace of C/C++ symbols")

--- a/lcm-python/BUILD.bazel
+++ b/lcm-python/BUILD.bazel
@@ -19,6 +19,7 @@ cc_binary(
     linkshared = True,
     visibility = ["//visibility:private"],
     deps = [
+        "//lcm:dbg-header-for-python",
         "//lcm:lcm-shared",
         "@rules_python//python/cc:current_py_cc_headers",
         "@rules_python//python/cc:current_py_cc_libs",

--- a/lcm/BUILD.bazel
+++ b/lcm/BUILD.bazel
@@ -1,8 +1,10 @@
 load("@bazel_skylib//lib:paths.bzl", "paths")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
 load("@bazel_skylib//rules:copy_file.bzl", "copy_file")
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
 load("@rules_cc//cc:cc_shared_library.bzl", "cc_shared_library")
 load("//lcm-bazel/private:copts.bzl", "WARNINGS_COPTS")
+load("//lcm-bazel/private:expand_flag_template.bzl", "expand_flag_template")
 
 package(
     default_applicable_licenses = ["//:license"],
@@ -28,6 +30,7 @@ LCM_SOURCES = [
 LCM_INSTALL_HEADERS = [
     "eventlog.h",
     "lcm.h",
+    "lcm_c_namespace.h",
     "lcm_coretypes.h",
     "lcm_version.h",
     "lcm-cpp.hpp",
@@ -61,6 +64,19 @@ LCM_COMPILE_DEFINITIONS_PRIVATE = [
 
 # Declare the libraries.
 
+string_flag(
+    name = "LCM_C_NAMESPACE",
+    build_setting_default = "lcm",
+)
+
+expand_flag_template(
+    name = "lcm_c_namespace.h",
+    flag_substitutions = {
+        "@LCM_C_NAMESPACE@": ":LCM_C_NAMESPACE",
+    },
+    template = "lcm_c_namespace.h.in",
+)
+
 LCM_PRIVATE_HEADERS = [
     "dbg.h",
     "ioutils.h",
@@ -72,28 +88,41 @@ LCM_PRIVATE_HEADERS = [
 ]
 
 [
-    # To obtain the correct include paths `<lcm/lcm.h>`, we need to copy public
-    # headers to a subdir now and then set `strip_include_prefix` later.
+    # To obtain the correct include path for `<lcm/lcm.h>` and allow relative
+    # include paths to our generated "lcm_c_namespace.h" header, we need to
+    # copy all code to a subdir now and then set `strip_include_prefix` later.
     copy_file(
-        name = "_add_hdrs_" + paths.basename(x),
+        name = "_copy_" + paths.basename(x),
         src = x,
-        out = "hdrs/lcm/" + x,
+        out = "copied/lcm/" + x,
     )
-    for x in LCM_INSTALL_HEADERS + LCM_INSTALL_HEADERS_WIN32
+    for x in (
+        LCM_INSTALL_HEADERS +
+        LCM_INSTALL_HEADERS_WIN32 +
+        LCM_PRIVATE_HEADERS +
+        LCM_SOURCES +
+        LCM_SOURCES_WIN32
+    )
 ]
 
 cc_library(
     name = "lcm-coretypes",
-    hdrs = ["hdrs/lcm/lcm_coretypes.h"],
-    strip_include_prefix = "/lcm/hdrs",
+    hdrs = ["copied/lcm/lcm_coretypes.h"],
+    strip_include_prefix = "/lcm/copied",
     visibility = ["//visibility:public"],
 )
 
 cc_library(
     name = "lcm-version",
-    hdrs = ["hdrs/lcm/lcm_version.h"],
-    strip_include_prefix = "/lcm/hdrs",
+    hdrs = ["copied/lcm/lcm_version.h"],
+    strip_include_prefix = "/lcm/copied",
     visibility = ["//lcmgen:__pkg__"],
+)
+
+cc_library(
+    name = "dbg-header-for-python",
+    hdrs = ["dbg.h"],
+    visibility = ["//lcm-python:__pkg__"],
 )
 
 config_setting(
@@ -106,8 +135,14 @@ config_setting(
     constraint_values = ["@platforms//os:windows"],
 )
 
-SRCS = LCM_SOURCES + LCM_PRIVATE_HEADERS + select({
-    ":windows": LCM_SOURCES_WIN32,
+SRCS = [
+    "copied/lcm/" + x
+    for x in LCM_SOURCES + LCM_PRIVATE_HEADERS
+] + select({
+    ":windows": [
+        "copied/lcm/" + x
+        for x in LCM_SOURCES_WIN32
+    ],
     "//conditions:default": [],
 })
 
@@ -119,16 +154,16 @@ HDRS = LCM_INSTALL_HEADERS + select({
 cc_library(
     name = "_public_hdrs",
     hdrs = [
-        "hdrs/lcm/" + x
+        "copied/lcm/" + x
         for x in LCM_INSTALL_HEADERS
     ] + select({
         ":windows": [
-            "hdrs/lcm/" + x
+            "copied/lcm/" + x
             for x in LCM_INSTALL_HEADERS_WIN32
         ],
         "//conditions:default": [],
     }),
-    strip_include_prefix = "/lcm/hdrs",
+    strip_include_prefix = "/lcm/copied",
 )
 
 COPTS = [

--- a/lcm/CMakeLists.txt
+++ b/lcm/CMakeLists.txt
@@ -2,6 +2,12 @@ if(UNIX)
   find_package(Threads)
 endif()
 
+configure_file(
+  lcm_c_namespace.h.in
+  lcm_c_namespace.h
+  @ONLY
+)
+
 set(lcm_sources
   eventlog.c
   lcm.c
@@ -23,6 +29,7 @@ set(lcm_install_headers
   lcm_version.h
   lcm-cpp.hpp
   lcm-cpp-impl.hpp
+  ${CMAKE_CURRENT_BINARY_DIR}/lcm_c_namespace.h
   ${CMAKE_CURRENT_BINARY_DIR}/lcm_export.h
 )
 

--- a/lcm/eventlog.h
+++ b/lcm/eventlog.h
@@ -4,6 +4,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "lcm_c_namespace.h"
+
 #ifdef LCM_PYTHON
 #define LCM_EXPORT
 #else
@@ -13,6 +15,13 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define lcm_eventlog_create LCM_C_NAMESPACED(eventlog_create)
+#define lcm_eventlog_read_next_event LCM_C_NAMESPACED(eventlog_read_next_event)
+#define lcm_eventlog_free_event LCM_C_NAMESPACED(eventlog_free_event)
+#define lcm_eventlog_seek_to_timestamp LCM_C_NAMESPACED(eventlog_seek_to_timestamp)
+#define lcm_eventlog_write_event LCM_C_NAMESPACED(eventlog_write_event)
+#define lcm_eventlog_destroy LCM_C_NAMESPACED(eventlog_destroy)
 
 /**
  * @defgroup LcmC_lcm_eventlog_t lcm_eventlog_t

--- a/lcm/lcm.h
+++ b/lcm/lcm.h
@@ -3,6 +3,7 @@
 
 #include <stdint.h>
 
+#include "lcm_c_namespace.h"
 #include "lcm_version.h"
 
 #ifdef LCM_PYTHON
@@ -20,6 +21,17 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+#define lcm_create LCM_C_NAMESPACED(create)
+#define lcm_destroy LCM_C_NAMESPACED(destroy)
+#define lcm_get_fileno LCM_C_NAMESPACED(get_fileno)
+#define lcm_subscribe LCM_C_NAMESPACED(subscribe)
+#define lcm_unsubscribe LCM_C_NAMESPACED(unsubscribe)
+#define lcm_publish LCM_C_NAMESPACED(publish)
+#define lcm_handle LCM_C_NAMESPACED(handle)
+#define lcm_handle_timeout LCM_C_NAMESPACED(handle_timeout)
+#define lcm_subscription_set_queue_capacity LCM_C_NAMESPACED(subscription_set_queue_capacity)
+#define lcm_subscription_get_queue_size LCM_C_NAMESPACED(subscription_get_queue_size)
 
 /**
  * @defgroup LcmC C API Reference

--- a/lcm/lcm_c_namespace.h.in
+++ b/lcm/lcm_c_namespace.h.in
@@ -1,0 +1,16 @@
+#ifndef __lcm_c_namespace_h__
+#define __lcm_c_namespace_h__
+
+/// This definition allows changing the name of public library symbols during
+/// the build process, to allow multiple independent versions of LCM to be
+/// linked into the same runtime process.
+#define LCM_C_NAMESPACE @LCM_C_NAMESPACE@
+
+// Utility macros for LCM_C_NAMSPACED, below.
+#define LCM_PP_CONCAT1(a, b) a##b
+#define LCM_PP_CONCAT(a, b) LCM_PP_CONCAT1(a, b)
+
+// Replaces `name` with `{LCM_C_NAMESPACE}_name`.
+#define LCM_C_NAMESPACED(name) LCM_PP_CONCAT(LCM_PP_CONCAT(LCM_C_NAMESPACE, _), name)
+
+#endif

--- a/lcm/meson.build
+++ b/lcm/meson.build
@@ -6,6 +6,12 @@ if unix
   lcm_extra_deps = [thread_dep]
 endif
 
+conf_data = configuration_data()
+conf_data.set('LCM_C_NAMESPACE', 'lcm')
+lcm_c_namespace_h = configure_file(input : 'lcm_c_namespace.h.in',
+                                   output : 'lcm_c_namespace.h',
+                                   configuration : conf_data)
+
 lcm_sources = ['eventlog.c',
                'lcm.c',
                'lcm_file.c',
@@ -24,6 +30,7 @@ install_headers('eventlog.h',
                 'lcm-cpp.hpp',
                 'lcm-cpp-impl.hpp',
                 'lcm_export.h',
+                lcm_c_namespace_h,
                 subdir : 'lcm')
 
 if windows 
@@ -36,14 +43,15 @@ endif
 lcm_lib = both_libraries('lcm', lcm_sources,
   dependencies : [glib_dep] + lcm_extra_deps,
   c_args : lcm_c_args,
-  install : true)
+  install : true,
+  include_directories : include_directories('.', '..'))
 lcm_lib_dep = declare_dependency(
   link_with : lcm_lib.get_shared_lib(),
   dependencies : [glib_dep] + lcm_extra_deps,
-  include_directories : include_directories('..'))
+  include_directories : include_directories('.', '..'))
 lcm_static_lib_dep = declare_dependency(
   link_with : lcm_lib.get_static_lib(),
   dependencies : [glib_dep] + lcm_extra_deps,
-  include_directories : include_directories('..'))
+  include_directories : include_directories('.', '..'))
 
 lcm_coretypes_lib = declare_dependency() # 'lcm-coretypes'


### PR DESCRIPTION
Add pre-processor option to change the C ABI symbol prefix. This allows multiple libraries to depend on independent copies of LCM.

There was already an LCM_NAMESPACE option for changing the names of the installed binaries, so the new option is LCM_C_NAMESPACE.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jwnimmer-tri/lcm/2)
<!-- Reviewable:end -->
